### PR TITLE
feat: 가상환경 설정

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -57,10 +57,13 @@ jobs:
 
           cd "$REMOTE_DIR"
 
+          # 가상환경 설정
+          python3 -m venv .venv
+          source .venv/bin/activate
+
           # .env 파일 생성
           cat <<EOT > .env
           OPENAI_API_KEY=$OPENAI_KEY
-          # 추가 환경 변수가 있다면 여기 추가
           EOT
 
           pip install -r requirements.txt


### PR DESCRIPTION
Ubuntu 24.04부터 Python 3.12 이상 버전에서는 '외부에서 관리되는 환경(externally-managed-environment)' 정책이 적용되어, 기본 Python 환경에 pip install을 통해 패키지를 전역 설치하는 것이 제한